### PR TITLE
header y footer reutilizables y otras yerbas

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Busco UNI - Home</title>
   <link rel="stylesheet" href="style.css">
-  <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css'>
 </head>
 
 <body>
@@ -16,23 +15,7 @@
 
     <!-- ////////////////////////////////////// HEADER //////////////////////////////////  -->
 
-
-            <!-- ////////////////////////////////////// HEADER //////////////////////////////////  -->
-
-    <header class="header">
-      <div class="site-name">
-        <img src="img/logogenerico.png" alt="Logo" class="logo" />
-        <h1 class="site-title">BUSCO UNI</h1>
-      </div>
-      <nav class="nav-container">
-        <ul class="nav-list">
-          <li class="nav-item"><a href="#">Inicio</a></li>
-          <li class="nav-item"><a href="#">Sobre Nosotros</a></li>
-          <li class="nav-item"><a href="detalle_carrera.html">Buscar Uni</a></li>
-          <li class="nav-item"><a href="#">Comparador</a></li>
-          <li class="nav-item"><a href="#">Test Vocacional</a></li>
-        </ul>
-      </nav>
+    <header>
     </header>
 
     <!-- ////////////////////////////////////// HERO //////////////////////////////////  -->
@@ -350,46 +333,7 @@
 
     <!-- ////////////////////////////////////// FOOTER //////////////////////////////////  -->
 
-    <footer class="footer">
-      <h2 class="footer-title">Busco UNI</h2>
-      <address class="footer-address">
-        Calle Falsa 123, San Luis, Argentina.
-      </address>
-      <nav class="footer-links">
-        Políticas de Privacidad | Términos y Condiciones
-      </nav>
-      <!-- <img src="" alt="Iconos redes sociales" class="footer-logo" /> -->
-      <div class="social-buttons">
-        <ul class="social-buttons-list">
-          <li>
-            <a class="facebook" href="#">
-              <span></span>
-              <span></span>
-              <span></span>
-              <span></span>
-              <i class="fa fa-facebook" aria-hidden="true"></i>
-            </a>
-          </li>
-          <li>
-            <a class="twitter" href="#">
-              <span></span>
-              <span></span>
-              <span></span>
-              <span></span>
-              <i class="fa fa-twitter" aria-hidden="true"></i>
-            </a>
-          </li>
-          <li>
-            <a class="instagram" href="#">
-              <span></span>
-              <span></span>
-              <span></span>
-              <span></span>
-              <i class="fa fa-instagram" aria-hidden="true"></i>
-            </a>
-          </li>
-        </ul>
-      </div>
+    <footer>
     </footer>
 
   </div>

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,4 +1,69 @@
+/* Esto agrega bootstrap (usado cuando menos para obtener los íconos de las redes sociales) en todas las páginas. */
 
+const head = document.querySelector("head");
+head.innerHTML += '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">';
+
+/* HEADER y FOOTER reutilizables por todas las páginas. */
+
+const header = document.querySelector("header");
+const footer = document.querySelector("footer");
+
+header.innerHTML = `
+<div class="site-name">
+  <img src="img/logogenerico.png" alt="Logo" class="logo" />
+  <h1 class="site-title">BUSCO UNI</h1>
+</div>
+<nav class="nav-container">
+  <ul class="nav-list">
+    <li><a href="#">Inicio</a></li>
+    <li><a href="#">Sobre Nosotros</a></li>
+    <li><a href="detalle_carrera.html">Buscar Uni</a></li>
+    <li><a href="#">Comparador</a></li>
+    <li><a href="#">Test Vocacional</a></li>
+  </ul>
+</nav>
+`;
+
+footer.innerHTML = `
+<h2 class="footer-title">Busco UNI</h2>
+<address class="footer-address">
+  Calle Falsa 123, San Luis, Argentina.
+</address>
+<nav class="footer-links">
+  Políticas de Privacidad | Términos y Condiciones
+</nav>
+<div class="social-buttons">
+  <ul class="social-buttons-list">
+    <li>
+      <a class="facebook" href="#">
+        <span></span>
+        <span></span>
+        <span></span>
+        <span></span>
+        <i class="bi bi-facebook"></i>
+      </a>
+    </li>
+    <li>
+      <a class="twitter-x" href="#">
+        <span></span>
+        <span></span>
+        <span></span>
+        <span></span>
+        <i class="bi bi-twitter-x"></i>
+      </a>
+    </li>
+    <li>
+      <a class="instagram" href="#">
+        <span></span>
+        <span></span>
+        <span></span>
+        <span></span>
+        <i class="bi bi-instagram"></i>
+      </a>
+    </li>
+  </ul>
+</div>
+`;
 
 /////////////////////////////////////////////////BUSCADOR - LANDING//////////////////////////////////////////////////////////////
 const inputCarrera = document.querySelector(".search-input");

--- a/public/style.css
+++ b/public/style.css
@@ -13,7 +13,7 @@
 
 /*   ////////////////////////////////////// HEADER ////////////////////////////////// */
 
-.header {
+header {
   /* align-items: start; ¿flex-start? */
   justify-content: space-between;
   border-bottom: 0.0625em solid rgba(128, 128, 128, 1);
@@ -23,7 +23,7 @@
   font-family: Poppins, sans-serif;
   font-size: 1em; /* Parece no incidir en nada. */
   font-weight: 600;
-  padding: 0.5em 5em;
+  padding: 0.5em 1em;
   align-items: center;
 }
 
@@ -1376,7 +1376,7 @@
 
 /*   ////////////////////////////////////// FOOTER ////////////////////////////////// */
 
-.footer {
+footer {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -1431,14 +1431,15 @@
   }
 }
 
-.footer-logo {
+/* NO HAY NADA QUE USE ESTA CLASE - BORRABLE */
+/* .footer-logo {
   width: 205px;
   max-width: 100%;
   margin-top: 1em;
   aspect-ratio: 5;
   object-fit: auto;
   object-position: center;
-}
+} */
 
 /* REDES SOCIALES */
 
@@ -1447,6 +1448,7 @@
   width: 30%;
   padding: 3%;
   /* background-color: #ebebeb; */
+  background-color: #a2aadd;
   position: relative;
   border-radius: 15px;
 }
@@ -1561,12 +1563,12 @@
   background: #3b5998;
 }
 
-.twitter:hover {
-  color: #1da1f2;
+.twitter-x:hover {
+  color: black;
 }
 
-.twitter:hover span {
-  background: #1da1f2;
+.twitter-x:hover span {
+  background: black;
 }
 
 .instagram:hover {
@@ -1575,6 +1577,11 @@
 
 .instagram:hover span {
   background: #c32aa3;
+}
+
+.bi-facebook, .bi-twitter-x, .bi-instagram {
+  font-size: 0.95em;
+  /* color: cornflowerblue; */
 }
 
 /* .social-buttons-list li a .twitter {


### PR DESCRIPTION
(1) cambié ícono de twitter/x, y el color de fondo de RRSS para mejorar el contraste durante el efecto hover.

(2) ajustado el padding dentro de header para que nombres de botones se muestren en 1 sola línea en el tamaño de página para monitor.

(3) removido el atributo class="nav-item" de las etiquetas li del menú, pues no había tal clase en el archivo de estilos.

(4) ahora es posible reutilizar el header y el footer en todas las páginas. Ese comportamiento fue agregado al archivo js.
Para reutilizar estos elementos, cada página tiene que tener:

`<header></header>` <-- vacío
`<footer></footer>` <-- vacío
`<script src="js/script.js"></script>` <-- antes de cerrar el body

Si se quisiese agregar un botón al menú, por ej, solo hay que modificar el js y el impacto será en todas las páginas.

(5) removí de los elementos html header y footer sus nombres de clase (.header y .footer), para eliminar redundancia. Nos referimos a ellos simplemente usando los selectores 'header' y footer' (en el css). Para las páginas que reutilicen estos elementos, bastará entonces agregar las etiquetas (como se detalla en (4)) sin preocuparse por agregar un nombre de clase, y los estilos serán aplicados automáticamente.

(6) Se agregó al js unas líneas que permiten que bootstrap esté disponible en todas las páginas (es usado cuando menos para obtener los íconos de las redes sociales).